### PR TITLE
Fix usernames and passwords with non-alphanumeric characters

### DIFF
--- a/app/src/main/java/org/tvheadend/tvhclient/ExternalActionActivity.java
+++ b/app/src/main/java/org/tvheadend/tvhclient/ExternalActionActivity.java
@@ -35,6 +35,8 @@ import org.tvheadend.tvhclient.model.Profile;
 import org.tvheadend.tvhclient.model.Recording;
 
 import java.io.File;
+import java.io.UnsupportedEncodingException;
+import java.net.URLEncoder;
 
 public class ExternalActionActivity extends Activity implements HTSListener, OnRequestPermissionsResultCallback {
 
@@ -89,7 +91,17 @@ public class ExternalActionActivity extends Activity implements HTSListener, OnR
 
         // Create the url with the credentials and the host and  
         // port configuration. This one is fixed for all actions
-        baseUrl = "http://" + conn.username + ":" + conn.password + "@" + conn.address + ":" + conn.streaming_port;
+        String encodedUsername = null;
+        String encodedPassword = null;
+        try {
+            encodedUsername = URLEncoder.encode(conn.username, "UTF-8");
+            encodedPassword = URLEncoder.encode(conn.password, "UTF-8");
+        } catch (UnsupportedEncodingException e) {
+            // Can't happen since encoding is statically specified
+            app.log(TAG, "Got impossible UnsupportedEncodingException");
+        }
+
+        baseUrl = "http://" + encodedUsername + ":" + encodedPassword + "@" + conn.address + ":" + conn.streaming_port;
 
         switch (action) {
         case Constants.EXTERNAL_ACTION_PLAY:


### PR DESCRIPTION
I have a password with non-alphanumeric characters, which works fine for HTSP-related stuff, but the base URL for HTTP streams is messed up. The PR fixes that for both username and password.
