### PR TITLE
Fixed date formatting

### DIFF
--- a/app/src/main/java/org/tvheadend/tvhclient/ui/common/DataBindingUtils.kt
+++ b/app/src/main/java/org/tvheadend/tvhclient/ui/common/DataBindingUtils.kt
@@ -573,32 +573,29 @@ fun setLocalizedDate(view: TextView, date: Long) {
 
     var dateDiff = date/ONE_DAY - System.currentTimeMillis()/ONE_DAY
 
-    if (dateDiff == 0) {
-        // Show the string today
-        localizedDate = view.context.getString(R.string.today)
-
-    } else if (dateDiff == 1) {
-        localizedDate = view.context.getString(R.string.tomorrow)
-
-    } else if (dateDiff < 7 && dateDiff > 2) {
-        val prefs = PreferenceManager.getDefaultSharedPreferences(view.context)
-        localizedDate = if (prefs.getBoolean("localized_date_time_format_enabled", false)) {
-            // Show the date as defined with the currently active locale.
-            // For the date display the short version will be used
-            val df = java.text.DateFormat.getDateInstance(java.text.DateFormat.SHORT, getLocale(view.context))
-            df.format(date)
-        } else {
-            // Show the date using the default format like 31.07.2013
-            val sdf = SimpleDateFormat("dd.MM.yyyy", Locale.US)
-            sdf.format(date)
+    when (dateDiff) {
+        0 -> localizedDate = view.context.getString(R.string.today)
+        1 -> localizedDate = view.context.getString(R.string.tomorrow)
+        -1 -> localizedDate = view.context.getString(R.string.yesterday)
+        -6, -5, -4, -3, -2, 2, 3, 4, 5, 6 -> {
+            // show matching day of week
+            val sdf = SimpleDateFormat("EEEE", getLocale(view.context))
+            localizedDate = sdf.format(date)
         }
-    } else {
-            // Show the date using the default format like 31.07.2013
-            val sdf = SimpleDateFormat("dd.MM.yyyy", Locale.US)
-            sdf.format(date)
+        default -> {
+            val prefs = PreferenceManager.getDefaultSharedPreferences(view.context)
+            localizedDate = if (prefs.getBoolean("localized_date_time_format_enabled", false)) {
+                // Show the date as defined with the currently active locale.
+                // For the date display the short version will be used
+                val df = java.text.DateFormat.getDateInstance(java.text.DateFormat.SHORT, getLocale(view.context))
+                df.format(date)
+            } else {
+                // Show the date using the default format like 31.07.2013
+                val sdf = SimpleDateFormat("dd.MM.yyyy", Locale.US)
+                sdf.format(date)
+            }
         }
     }
-
     view.text = localizedDate
 }
 

--- a/app/src/main/java/org/tvheadend/tvhclient/ui/common/DataBindingUtils.kt
+++ b/app/src/main/java/org/tvheadend/tvhclient/ui/common/DataBindingUtils.kt
@@ -571,14 +571,16 @@ fun setLocalizedDate(view: TextView, date: Long) {
 
     var localizedDate = ""
 
-    if (DateUtils.isToday(date)) {
+    var dateDiff = date/ONE_DAY - System.currentTimeMillis()/ONE_DAY
+
+    if (dateDiff == 0) {
         // Show the string today
         localizedDate = view.context.getString(R.string.today)
 
-    } else if (date < System.currentTimeMillis() + ONE_DAY && date > System.currentTimeMillis()) {
+    } else if (dateDiff == 1) {
         localizedDate = view.context.getString(R.string.tomorrow)
 
-    } else if (date < System.currentTimeMillis() + SIX_DAYS && date > System.currentTimeMillis() - TWO_DAYS) {
+    } else if (dateDiff < 7 && dateDiff > 2) {
         val prefs = PreferenceManager.getDefaultSharedPreferences(view.context)
         localizedDate = if (prefs.getBoolean("localized_date_time_format_enabled", false)) {
             // Show the date as defined with the currently active locale.
@@ -586,6 +588,11 @@ fun setLocalizedDate(view: TextView, date: Long) {
             val df = java.text.DateFormat.getDateInstance(java.text.DateFormat.SHORT, getLocale(view.context))
             df.format(date)
         } else {
+            // Show the date using the default format like 31.07.2013
+            val sdf = SimpleDateFormat("dd.MM.yyyy", Locale.US)
+            sdf.format(date)
+        }
+    } else {
             // Show the date using the default format like 31.07.2013
             val sdf = SimpleDateFormat("dd.MM.yyyy", Locale.US)
             sdf.format(date)

--- a/app/src/main/java/org/tvheadend/tvhclient/ui/common/DataBindingUtils.kt
+++ b/app/src/main/java/org/tvheadend/tvhclient/ui/common/DataBindingUtils.kt
@@ -582,7 +582,7 @@ fun setLocalizedDate(view: TextView, date: Long) {
             val sdf = SimpleDateFormat("EEEE", getLocale(view.context))
             localizedDate = sdf.format(date)
         }
-        default -> {
+        else -> {
             val prefs = PreferenceManager.getDefaultSharedPreferences(view.context)
             localizedDate = if (prefs.getBoolean("localized_date_time_format_enabled", false)) {
                 // Show the date as defined with the currently active locale.


### PR DESCRIPTION
Hi Robert,
I found a problem with date formatting in TVHClient: Dates outside the current week are not shown at all, while days within the current week are sometimes wrong.
I fixed the date formatting code (hopefully; haven't tested it yet, but the changes seem pretty straightforward). Feel free to include the changes in the next version. It might also make sense to include a "yesterday" label for dateDiff == -1.
Best wishes, Sören